### PR TITLE
fix : Multiple F/P when a player has recently picked up velocity

### DIFF
--- a/src/main/java/me/tecnio/antihaxerman/check/impl/movement/flight/FlightB.java
+++ b/src/main/java/me/tecnio/antihaxerman/check/impl/movement/flight/FlightB.java
@@ -41,9 +41,13 @@ public final class FlightB extends Check {
 
             final int clientAirTicks = data.getPositionProcessor().getClientAirTicks();
 
-            final boolean exempt = isExempt(ExemptType.VELOCITY, ExemptType.PISTON, ExemptType.VEHICLE,
+            final boolean exempt = isExempt(
+                    ExemptType.PISTON, ExemptType.VEHICLE,
                     ExemptType.TELEPORT, ExemptType.LIQUID, ExemptType.BOAT, ExemptType.FLYING,
-                    ExemptType.WEB, ExemptType.SLIME, ExemptType.CLIMBABLE);
+                    ExemptType.WEB, ExemptType.SLIME, ExemptType.CLIMBABLE,
+
+                    ExemptType.VELOCITY, ExemptType.VELOCITY_ON_TICK, ExemptType.VELOCITY_RECENTLY
+            );
             final boolean invalid = (clientAirTicks > airTicksLimit) && deltaY > 0.0;
 
             if (invalid && !exempt) {

--- a/src/main/java/me/tecnio/antihaxerman/check/impl/movement/motion/MotionA.java
+++ b/src/main/java/me/tecnio/antihaxerman/check/impl/movement/motion/MotionA.java
@@ -51,7 +51,13 @@ public final class MotionA extends Check {
             final double modifierJump = PlayerUtil.getPotionLevel(data.getPlayer(), PotionEffectType.JUMP) * 0.1F;
             final double expectedJumpMotion = 0.42F + modifierJump;
 
-            final boolean exempt = isExempt(ExemptType.VEHICLE, ExemptType.CLIMBABLE, ExemptType.VELOCITY, ExemptType.PISTON, ExemptType.LIQUID, ExemptType.TELEPORT, ExemptType.WEB, ExemptType.BOAT, ExemptType.FLYING, ExemptType.SLIME, ExemptType.UNDERBLOCK, ExemptType.CHUNK) || data.getPositionProcessor().getSinceBlockNearHeadTicks() < 5;
+            final boolean exempt = isExempt(
+                    ExemptType.VELOCITY, ExemptType.VELOCITY_ON_TICK, ExemptType.VELOCITY_RECENTLY,
+
+                    ExemptType.VEHICLE, ExemptType.CLIMBABLE, ExemptType.PISTON, ExemptType.LIQUID, ExemptType.TELEPORT, ExemptType.WEB,
+                    ExemptType.BOAT, ExemptType.FLYING, ExemptType.SLIME, ExemptType.UNDERBLOCK, ExemptType.CHUNK)
+                    || data.getPositionProcessor().getSinceBlockNearHeadTicks() < 5;
+
             final boolean invalid = deltaY != expectedJumpMotion && deltaY > 0.0 && !onGround && lastGround && !step;
 
             if (invalid && !exempt) fail(deltaY + " vel: " + isExempt(ExemptType.VELOCITY));

--- a/src/main/java/me/tecnio/antihaxerman/check/impl/movement/motion/MotionD.java
+++ b/src/main/java/me/tecnio/antihaxerman/check/impl/movement/motion/MotionD.java
@@ -42,7 +42,10 @@ public final class MotionD extends Check {
             final double maximum = 0.6 + modifierJump + modifierVelocity;
 
             final boolean exempt = isExempt(ExemptType.PISTON, ExemptType.LIQUID,
-                    ExemptType.FLYING, ExemptType.WEB, ExemptType.TELEPORT, ExemptType.SLIME, ExemptType.CHUNK, ExemptType.BOAT);
+                    ExemptType.FLYING, ExemptType.WEB, ExemptType.TELEPORT, ExemptType.SLIME, ExemptType.CHUNK, ExemptType.BOAT,
+
+                    ExemptType.VELOCITY_ON_TICK, ExemptType.VELOCITY_RECENTLY
+            );
             final boolean invalid = deltaY > maximum;
 
             if (invalid && !exempt) fail();

--- a/src/main/java/me/tecnio/antihaxerman/check/impl/movement/speed/SpeedC.java
+++ b/src/main/java/me/tecnio/antihaxerman/check/impl/movement/speed/SpeedC.java
@@ -91,8 +91,12 @@ public final class SpeedC extends Check {
                 groundLimit += 0.1;
             }
 
-            final boolean exempt = isExempt(ExemptType.VEHICLE, ExemptType.PISTON,
-                    ExemptType.FLYING, ExemptType.TELEPORT, ExemptType.CHUNK);
+            final boolean exempt = isExempt(
+                    ExemptType.VEHICLE, ExemptType.PISTON,
+                    ExemptType.FLYING, ExemptType.TELEPORT, ExemptType.CHUNK,
+
+                    ExemptType.VELOCITY, ExemptType.VELOCITY_ON_TICK, ExemptType.VELOCITY_RECENTLY
+            );
 
             if (!exempt) {
                 if (airTicks > 0) {

--- a/src/main/java/me/tecnio/antihaxerman/exempt/type/ExemptType.java
+++ b/src/main/java/me/tecnio/antihaxerman/exempt/type/ExemptType.java
@@ -44,6 +44,8 @@ public enum ExemptType {
 
     VELOCITY_ON_TICK(data -> data.getVelocityProcessor().getTakingVelocityTicks() == 1),
 
+    VELOCITY_RECENTLY(data -> data.getVelocityProcessor().getTicksSinceVelocity() < 20),
+
     SLIME(data -> data.getPositionProcessor().getSinceSlimeTicks() < 20),
 
     SLIME_ON_TICK(data -> data.getPositionProcessor().getSinceSlimeTicks() < 2),


### PR DESCRIPTION

Motion A / Motion D / Speed C / Flight B : When a player has recently gained velocity (directly on the same tick or a few ticks ago) the different checks make false positives.

For example the player is sent in the air checks are made when he is in the air but is "taking" the recently applied velocity.